### PR TITLE
Add methods to extract column arrays from BaseTable

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import GeneticInheritanceGraph as gig
 import msprime
 import pytest
+import tests.util_tests as util_tests
 
 
 @pytest.fixture(scope="session")
@@ -11,7 +12,8 @@ def simple_ts():
 
 
 @pytest.fixture(scope="session")
-def simple_gig():
+def all_mutation_types_gig():
+    # p | c | c_left | c_right | p_left | p_right
     interval_data = [
         (6, 0, 0, 300, 0, 300),
         (6, 1, 0, 300, 0, 300),
@@ -30,7 +32,7 @@ def simple_gig():
         (12, 8, 160, 200, 160, 200),
         (12, 11, 0, 200, 0, 200),
     ]
-
+    # time | flags
     node_data = [
         (0, 1),
         (0, 1),
@@ -48,15 +50,30 @@ def simple_gig():
     ]
 
     table_group = gig.TableGroup()
-    for row in interval_data:
-        table_group.intervals.add_row(
-            parent=row[0],
-            child=row[1],
-            child_left=row[2],
-            child_right=row[3],
-            parent_left=row[4],
-            parent_right=row[5],
-        )
-    for row in node_data:
-        table_group.nodes.add_row(time=row[0], flags=row[1], individual=gig.NULL)
+    table_group.intervals = util_tests.make_intervals_table(interval_data, table_group)
+    table_group.nodes = util_tests.make_nodes_table(node_data, table_group)
+    return table_group
+
+
+@pytest.fixture(scope="session")
+def trivial_gig():
+    # p | c | c_left | c_right | p_left | p_right
+    interval_data = [
+        (4, 3, 0, 5, 0, 5),
+        (3, 0, 3, 0, 0, 3),
+        (3, 0, 3, 5, 3, 5),
+        (4, 1, 0, 5, 0, 5),
+        (4, 2, 0, 5, 0, 5),
+    ]
+    # time | flags
+    node_data = [
+        (0, 1),
+        (0, 1),
+        (0, 1),
+        (1, 0),
+        (2, 0),
+    ]
+    table_group = gig.TableGroup()
+    table_group.intervals = util_tests.make_intervals_table(interval_data, table_group)
+    table_group.nodes = util_tests.make_nodes_table(node_data, table_group)
     return table_group

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -1,4 +1,5 @@
 import GeneticInheritanceGraph as gig
+import numpy as np
 import pytest
 
 
@@ -15,3 +16,20 @@ class TestCreation:
         assert simple_ts.num_trees > 1
         g = gig.TableGroup.from_tree_sequence(simple_ts, timedelta=time)
         assert g.nodes[0].time == simple_ts.node(0).time + time
+
+
+class TestExtractColumn:
+    # Test extraction of columns from a gig
+
+    def test_incorrect_column_error(self, trivial_gig):
+        with pytest.raises(AttributeError):
+            trivial_gig.nodes.foo
+
+    def test_column_from_empty_table(self, trivial_gig):
+        assert len(trivial_gig.individuals.parents) == 0
+
+    def test_extracted_columns(self, trivial_gig):
+        assert np.array_equal(trivial_gig.nodes.time, [0, 0, 0, 1, 2])
+        assert np.array_equal(trivial_gig.nodes.flags, [1, 1, 1, 0, 0])
+        assert np.array_equal(trivial_gig.intervals.parent, [4, 3, 3, 4, 4])
+        assert np.array_equal(trivial_gig.intervals.child_left, [0, 3, 3, 0, 0])

--- a/tests/util_tests.py
+++ b/tests/util_tests.py
@@ -1,0 +1,26 @@
+import GeneticInheritanceGraph as gig
+
+
+def make_intervals_table(arr, table_group):
+    """
+    Make an intervals table from a list of tuples.
+    """
+    for row in arr:
+        table_group.intervals.add_row(
+            parent=row[0],
+            child=row[1],
+            child_left=row[2],
+            child_right=row[3],
+            parent_left=row[4],
+            parent_right=row[5],
+        )
+    return table_group.intervals
+
+
+def make_nodes_table(arr, table_group):
+    """
+    Make a nodes table from a list of tuples.
+    """
+    for row in arr:
+        table_group.nodes.add_row(time=row[0], flags=row[1], individual=gig.NULL)
+    return table_group.nodes


### PR DESCRIPTION
Fixes #19.

I've added an `extract_column` method to the BaseTable class, which can be called directly like `TableGroup.intervals.extract_column(col_name='parent')` or by using the shorthand we discussed in #19: `TableGroup.intervals.parent`. I've also added rudimentary tests for the method with a simple gig, along with some util functions to make it easier to create gigs from arrays of data.

@hyanwong any changes you suggest?