### PR TITLE
Change to integer intervals, Use "IEdge" rather than "Edge"

### DIFF
--- a/GeneticInheritanceGraph/__init__.py
+++ b/GeneticInheritanceGraph/__init__.py
@@ -1,10 +1,14 @@
 import sys
 
+import tskit
+
 if sys.version_info[0] < 3:  # pragma: no cover
     raise Exception("Python 3 only")
 
-from .tables import NULL  # noqa: F401
 from .tables import Tables  # noqa: F401
 from .util import set_print_options  # noqa: F401
+
+NODE_IS_SAMPLE = tskit.NODE_IS_SAMPLE  # noqa: F401
+NULL = tskit.NULL  # noqa: F401
 
 _print_options = {"max_lines": 40}

--- a/GeneticInheritanceGraph/__init__.py
+++ b/GeneticInheritanceGraph/__init__.py
@@ -1,14 +1,10 @@
 import sys
 
-import tskit
-
 if sys.version_info[0] < 3:  # pragma: no cover
     raise Exception("Python 3 only")
 
 from .tables import Tables  # noqa: F401
 from .util import set_print_options  # noqa: F401
-
-NODE_IS_SAMPLE = tskit.NODE_IS_SAMPLE  # noqa: F401
-NULL = tskit.NULL  # noqa: F401
+from .constants import NODE_IS_SAMPLE, NULL  # noqa: F401
 
 _print_options = {"max_lines": 40}

--- a/GeneticInheritanceGraph/__init__.py
+++ b/GeneticInheritanceGraph/__init__.py
@@ -4,7 +4,7 @@ if sys.version_info[0] < 3:  # pragma: no cover
     raise Exception("Python 3 only")
 
 from .tables import NULL  # noqa: F401
-from .tables import TableGroup  # noqa: F401
+from .tables import Tables  # noqa: F401
 from .util import set_print_options  # noqa: F401
 
 _print_options = {"max_lines": 40}

--- a/GeneticInheritanceGraph/constants.py
+++ b/GeneticInheritanceGraph/constants.py
@@ -1,0 +1,4 @@
+import tskit
+
+NODE_IS_SAMPLE = tskit.NODE_IS_SAMPLE  # noqa: F401
+NULL = tskit.NULL  # noqa: F401

--- a/GeneticInheritanceGraph/tables.py
+++ b/GeneticInheritanceGraph/tables.py
@@ -244,7 +244,7 @@ class NodeTable(BaseTable):
 
     @property
     def time(self) -> npt.NDArray[np.float64]:
-        return np.array([row.time for row in self.data], dtype=np.uint32)
+        return np.array([row.time for row in self.data], dtype=np.float64)
 
 
 class IndividualTable(BaseTable):

--- a/GeneticInheritanceGraph/tables.py
+++ b/GeneticInheritanceGraph/tables.py
@@ -5,10 +5,9 @@ import numpy.typing as npt
 import pandas as pd
 import tskit
 
+from .constants import NODE_IS_SAMPLE
+from .constants import NULL
 from .util import truncate_rows
-
-NULL = -1
-NODE_IS_SAMPLE = tskit.NODE_IS_SAMPLE
 
 
 @dataclasses.dataclass

--- a/GeneticInheritanceGraph/tables.py
+++ b/GeneticInheritanceGraph/tables.py
@@ -19,8 +19,17 @@ class IEdgeTableRow:
     child_left: int
     parent_right: int
     child_right: int
-    parent_chromosome: int = None
-    child_chromosome: int = None
+    edge: int = NULL
+    parent_chromosome: int = NULL
+    child_chromosome: int = NULL
+
+    @property
+    def parent_span(self):
+        return self.parent_right - self.parent_left
+
+    @property
+    def child_span(self):
+        return self.child_right - self.child_left
 
 
 @dataclasses.dataclass
@@ -219,6 +228,13 @@ class IEdgeTable(BaseTable):
         """
         return np.array([row.parent_right for row in self.data], dtype=np.int64)
 
+    @property
+    def edge(self) -> npt.NDArray[np.int64]:
+        """
+        Return a numpy array of edge IDs
+        """
+        return np.array([row.edge for row in self.data], dtype=np.int64)
+
 
 class NodeTable(BaseTable):
     RowClass = NodeTableRow
@@ -259,14 +275,15 @@ class Tables:
 
     def samples(self):
         """
-        Return the IDs of all samples in the graph
+        Return the IDs of all samples in the nodes table
         """
         return np.where(self.nodes.flags & NODE_IS_SAMPLE)[0]
 
     @classmethod
     def from_tree_sequence(cls, ts, *, chromosome=None, timedelta=0, **kwargs):
         """
-        Create a GIG Tables object from a tree sequence.
+        Create a GIG Tables object from a tree sequence. To create a GIG
+        directly, use GIG.from_tree_sequence() which simply wraps this method.
 
         :param tskit.TreeSequence ts: The tree sequence on which to base the Tables
             object

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,9 +34,9 @@ def ts_with_multiple_pops():
 
 
 @pytest.fixture(scope="session")
-def all_mutation_types_gig():
+def all_sv_types_gig():
     # p | c | c_left | c_right | p_left | p_right
-    interval_data = [
+    iedge_data = [
         (6, 0, 0, 300, 0, 300),
         (6, 1, 0, 300, 0, 300),
         (9, 6, 0, 200, 0, 200),
@@ -71,16 +71,16 @@ def all_mutation_types_gig():
         (6, 0),
     ]
 
-    table_group = gig.TableGroup()
-    table_group.intervals = gigutil.make_intervals_table(interval_data, table_group)
-    table_group.nodes = gigutil.make_nodes_table(node_data, table_group)
-    return table_group
+    tables = gig.Tables()
+    tables.iedges = gigutil.make_iedges_table(iedge_data, tables)
+    tables.nodes = gigutil.make_nodes_table(node_data, tables)
+    return tables
 
 
 @pytest.fixture(scope="session")
 def trivial_gig():
     # p | c | c_left | c_right | p_left | p_right
-    interval_data = [
+    iedge_data = [
         (4, 3, 0, 5, 0, 5),
         (3, 0, 3, 0, 0, 3),
         (3, 0, 3, 5, 3, 5),
@@ -95,14 +95,16 @@ def trivial_gig():
         (1, 0),
         (2, 0),
     ]
-    table_group = gig.TableGroup()
-    table_group.intervals = gigutil.make_intervals_table(interval_data, table_group)
-    table_group.nodes = gigutil.make_nodes_table(node_data, table_group)
-    return table_group
+    tables = gig.Tables()
+    tables.intervals = gigutil.make_iedges_table(iedge_data, tables)
+    tables.nodes = gigutil.make_nodes_table(node_data, tables)
+    return tables
 
 
 @pytest.fixture(scope="session")
 def gig_from_degree2_ts():
-    ts = msprime.simulate(10, recombination_rate=0.2, random_seed=1)
+    ts = msprime.sim_ancestry(
+        5, sequence_length=10, recombination_rate=0.02, random_seed=1
+    )
     assert ts.num_trees == 2
-    return gig.TableGroup.from_tree_sequence(ts)
+    return gig.Tables.from_tree_sequence(ts)

--- a/tests/gigutil.py
+++ b/tests/gigutil.py
@@ -3,12 +3,12 @@ import GeneticInheritanceGraph as gig
 # Utilities for creating and editing gigs
 
 
-def make_intervals_table(arr, table_group):
+def make_iedges_table(arr, tables):
     """
     Make an intervals table from a list of tuples.
     """
     for row in arr:
-        table_group.intervals.add_row(
+        tables.iedges.add_row(
             parent=row[0],
             child=row[1],
             child_left=row[2],
@@ -16,13 +16,13 @@ def make_intervals_table(arr, table_group):
             parent_left=row[4],
             parent_right=row[5],
         )
-    return table_group.intervals
+    return tables.iedges
 
 
-def make_nodes_table(arr, table_group):
+def make_nodes_table(arr, tables):
     """
     Make a nodes table from a list of tuples.
     """
     for row in arr:
-        table_group.nodes.add_row(time=row[0], flags=row[1], individual=gig.NULL)
-    return table_group.nodes
+        tables.nodes.add_row(time=row[0], flags=row[1], individual=gig.NULL)
+    return tables.nodes

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -7,37 +7,44 @@ class TestCreation:
     # Test creation of a set of GiGtables
     def test_simple_from_tree_sequence(self, simple_ts):
         assert simple_ts.num_trees > 1
-        g = gig.TableGroup.from_tree_sequence(simple_ts)
-        assert len(g.nodes) == simple_ts.num_nodes
-        assert len(g.intervals) == simple_ts.num_edges
+        tables = gig.Tables.from_tree_sequence(simple_ts)
+        assert len(tables.nodes) == simple_ts.num_nodes
+        assert len(tables.iedges) == simple_ts.num_edges
+        # test conversion from float to int for genomic coordinates
+        assert simple_ts.edges_left.dtype == np.float64
+        assert tables.iedges.parent_left.dtype == np.int64
+        assert tables.iedges.child_left.dtype == np.int64
+        assert simple_ts.edges_right.dtype == np.float64
+        assert tables.iedges.parent_right.dtype == np.int64
+        assert tables.iedges.child_right.dtype == np.int64
 
     @pytest.mark.parametrize("time", [0, 1])
     def test_simple_from_tree_sequence_with_timedelta(self, simple_ts, time):
         assert simple_ts.num_trees > 1
-        g = gig.TableGroup.from_tree_sequence(simple_ts, timedelta=time)
-        assert g.nodes[0].time == simple_ts.node(0).time + time
+        tables = gig.Tables.from_tree_sequence(simple_ts, timedelta=time)
+        assert tables.nodes[0].time == simple_ts.node(0).time + time
 
     def test_mutations_not_implemented_error(self, simple_ts_with_mutations):
-        tables = simple_ts_with_mutations.tables
-        assert tables.mutations.num_rows > 0
-        assert tables.sites.num_rows > 0
+        ts_tables = simple_ts_with_mutations.tables
+        assert ts_tables.mutations.num_rows > 0
+        assert ts_tables.sites.num_rows > 0
         with pytest.raises(NotImplementedError):
-            gig.TableGroup.from_tree_sequence(simple_ts_with_mutations)
+            gig.Tables.from_tree_sequence(simple_ts_with_mutations)
 
     def test_populations_not_implemented_error(self, ts_with_multiple_pops):
         # No need to test for migrations, since they necessarily
         # have multiple populations
-        tables = ts_with_multiple_pops.tables
-        assert tables.populations.num_rows > 1
+        ts_tables = ts_with_multiple_pops.tables
+        assert ts_tables.populations.num_rows > 1
         with pytest.raises(NotImplementedError):
-            gig.TableGroup.from_tree_sequence(ts_with_multiple_pops)
+            gig.Tables.from_tree_sequence(ts_with_multiple_pops)
 
 
 class TestExtractColumn:
     # Test extraction of columns from a gig
     def test_invalid_column_name(self, trivial_gig):
         with pytest.raises(AttributeError):
-            trivial_gig.intervals.foobar
+            trivial_gig.iedges.foobar
 
     def test_column_from_empty_table(self, trivial_gig):
         assert len(trivial_gig.individuals.parents) == 0
@@ -45,8 +52,8 @@ class TestExtractColumn:
     def test_extracted_columns(self, trivial_gig):
         assert np.array_equal(trivial_gig.nodes.time, [0, 0, 0, 1, 2])
         assert np.array_equal(trivial_gig.nodes.flags, [1, 1, 1, 0, 0])
-        assert np.array_equal(trivial_gig.intervals.parent, [4, 3, 3, 4, 4])
-        assert np.array_equal(trivial_gig.intervals.child_left, [0, 3, 3, 0, 0])
+        assert np.array_equal(trivial_gig.iedges.parent, [4, 3, 3, 4, 4])
+        assert np.array_equal(trivial_gig.iedges.child_left, [0, 3, 3, 0, 0])
 
 
 class TestBaseTable:
@@ -66,29 +73,29 @@ class TestStringRepresentations:
         assert "tskit" not in output
 
     def test_identifiable_values_from_str(self):
-        table_group = gig.TableGroup()
+        tables = gig.Tables()
         nodes = [(0, 3.1451), (1, 7.4234)]
-        interval = [1, 0, 0.9876, 6.7890, 0.9876, 6.7890]
+        iedge = [1, 0, 0.9876, 6.7890, 0.9876, 6.7890]
         for node in nodes:
-            table_group.nodes.add_row(time=node[0], flags=node[1])
-        table_group.intervals.add_row(
-            parent=interval[0],
-            child=interval[1],
-            child_left=interval[2],
-            child_right=interval[3],
-            parent_left=interval[4],
-            parent_right=interval[5],
+            tables.nodes.add_row(time=node[0], flags=node[1])
+        tables.iedges.add_row(
+            parent=iedge[0],
+            child=iedge[1],
+            child_left=iedge[2],
+            child_right=iedge[3],
+            parent_left=iedge[4],
+            parent_right=iedge[5],
         )
         for node in nodes:
-            assert str(node[0]) in str(table_group)
-            assert str(node[1]) in str(table_group)
-        for value in interval:
-            assert str(value) in str(table_group)
+            assert str(node[0]) in str(tables)
+            assert str(node[1]) in str(tables)
+        for value in iedge:
+            assert str(value) in str(tables)
 
     @pytest.mark.parametrize("num_rows", [0, 10, 40, 50])
     def test_repr_html(self, num_rows):
         # Based on the corresponding test code in tskit
-        nodes = gig.TableGroup().nodes
+        nodes = gig.Tables().nodes
         for _ in range(num_rows):
             nodes.append({"time": 0, "flags": 0})
         html = nodes._repr_html_()
@@ -100,3 +107,27 @@ class TestStringRepresentations:
             )
         else:
             assert len(html.splitlines()) == num_rows + 20
+
+
+class TestIEdgeAttributes:
+    @pytest.mark.parametrize(
+        "name",
+        ["parent", "child", "parent_left", "parent_right", "child_left", "child_right"],
+    )
+    def test_attributes(self, simple_ts, name):
+        tables = gig.Tables.from_tree_sequence(simple_ts)
+        assert getattr(tables.iedges, name).dtype == np.int64
+        suffix = name.split("_")[-1]
+        assert np.all(
+            getattr(tables.iedges, name) == getattr(simple_ts, "edges_" + suffix)
+        )
+
+
+class TestNodeAttributes:
+    def test_flags(self, simple_ts):
+        tables = gig.Tables.from_tree_sequence(simple_ts)
+        assert np.all(tables.nodes.flags == simple_ts.nodes_flags)
+
+    def test_child(self, simple_ts):
+        tables = gig.Tables.from_tree_sequence(simple_ts)
+        assert np.all(tables.iedges.child == simple_ts.edges_child)

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -87,7 +87,7 @@ class TestBaseTable:
 
 
 class TestIEdgeTable:
-    def test_append_integer_coords(self, trivial_gig):
+    def test_append_integer_coords(self):
         tables = gig.Tables()
         u = tables.nodes.add_row(flags=gig.NODE_IS_SAMPLE, time=0)
         tables.iedges.add_row(0, u, 0, 1, 1, 0)

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -87,7 +87,7 @@ class TestBaseTable:
 
 
 class TestIEdgeTable:
-    def test_append_integer_coords(trivial_gig):
+    def test_append_integer_coords(self, trivial_gig):
         tables = gig.Tables()
         u = tables.nodes.add_row(flags=gig.NODE_IS_SAMPLE, time=0)
         tables.iedges.add_row(0, u, 0, 1, 1, 0)
@@ -106,7 +106,7 @@ class TestStringRepresentations:
     def test_identifiable_values_from_str(self):
         tables = gig.Tables()
         nodes = [(0, 3.1451), (1, 7.4234)]
-        iedge = [1, 0, 0.9876, 6.7890, 0.9876, 6.7890]
+        iedge = [1, 0, 222, 777, 322, 877]
         for node in nodes:
             tables.nodes.add_row(time=node[0], flags=node[1])
         tables.iedges.add_row(


### PR DESCRIPTION
 and rename  "TableGroup" to "Tables". We can refer to the tree sequence tables as `ts_tables` when used in a variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Renamed key components to align with updated data structure terminology.
  - Updated attribute types for improved data integrity.

- **New Features**
  - Introduced a method for retrieving sample IDs, enhancing data accessibility.

- **Tests**
  - Adjusted test cases to reflect the refactored codebase and new naming conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->