### PR TITLE
Add the graph object

### DIFF
--- a/GeneticInheritanceGraph/__init__.py
+++ b/GeneticInheritanceGraph/__init__.py
@@ -4,6 +4,7 @@ if sys.version_info[0] < 3:  # pragma: no cover
     raise Exception("Python 3 only")
 
 from .tables import Tables  # noqa: F401
+from .graph import from_tree_sequence, Graph  # noqa: F401
 from .util import set_print_options  # noqa: F401
 from .constants import NODE_IS_SAMPLE, NULL  # noqa: F401
 

--- a/GeneticInheritanceGraph/graph.py
+++ b/GeneticInheritanceGraph/graph.py
@@ -1,0 +1,299 @@
+"""
+Define a generalised (genetic) inheritance graph object, which is
+a validated set of GIG tables with some extra indexes etc for
+efficient access.
+"""
+import dataclasses
+
+import numpy as np
+import portion as P
+
+from .tables import IEdgeTableRow
+from .tables import NodeTableRow
+from .tables import Tables
+
+
+def from_tree_sequence(ts):
+    """
+    Construct a GIG from a tree sequence
+    """
+    return Graph(Tables.from_tree_sequence(ts))
+
+
+class Graph:
+    def __init__(self, tables):
+        """
+        Create a gig.Graph from a set of Tables. This is for internal use only:
+        the canonical way to do this is to use tables.Graph()
+        """
+        if not isinstance(tables, Tables):
+            raise ValueError("tables must be a GeneticInhertanceGraph.Tables object")
+        self.tables = tables
+        self._validate()
+
+    def _validate(self):
+        assert hasattr(self, "tables")
+        # Extra validation for a GIG here, e.g. edge transformations are
+        # valid, etc.
+
+        # Cached variables
+        self.parent_range = -np.ones((self.num_nodes, 2), dtype=np.int32)
+        self.child_range = -np.ones((self.num_nodes, 2), dtype=np.int32)
+
+        if len(self.tables.iedges) == 0:
+            return
+
+        iedges_child = self.tables.iedges.child
+        iedges_parent = self.tables.iedges.parent
+        # Check that all node IDs are non-negative and less than num_nodes
+        for nm, nodes in (("child", iedges_child), ("parent", iedges_parent)):
+            if nodes.min() < 0:
+                raise ValueError(f"Iedge {np.argmin(nodes)} contains negative {nm} ID.")
+            if nodes.max() >= self.num_nodes:
+                raise ValueError(
+                    f"Iedge {np.argmax(nodes)} contains {nm} ID >= num nodes"
+                )
+
+        # check all parents are strictly older than their children
+        node_times = self.tables.nodes.time
+        for i, ie in enumerate(self.iedges):
+            if node_times[ie.parent] <= node_times[ie.child]:
+                raise ValueError(
+                    f"Edge {i}: child node {ie.child} older than parent {ie.parent}"
+                )
+
+        # Check that all iedges have same absolute parent span as child span
+        parent_spans = self.tables.iedges.parent_right - self.tables.iedges.parent_left
+        child_spans = self.tables.iedges.child_right - self.tables.iedges.child_left
+        span_equal = np.abs(parent_spans) == np.abs(child_spans)
+        if not np.all(span_equal):
+            bad = np.where(~span_equal)[0]
+            raise ValueError(f"iedges {bad} have different parent and child spans")
+
+        # Check that parent left is always < parent right
+        if np.any(child_spans < 0):
+            raise ValueError(
+                f"parent_left > parent_right for iedges {np.where(child_spans < 0)[0]}"
+            )
+
+        # Check iedges are sorted so that all parent IDs are adjacent
+        iedges_parent = self.tables.iedges.parent
+        tot_parents = len(np.unique(iedges_parent))
+        if np.sum(np.diff(iedges_parent) != 0) != tot_parents - 1:
+            raise ValueError("iedges are not sorted by parent ID")
+
+        # Check iedges are also sorted by parent time
+        assert np.all(np.diff(self.tables.nodes.time[iedges_parent]) >= 0)
+
+        # Create the cached variables
+
+        # index to sort edges so they are sorted by child time
+        # and grouped by child id. Within each group with the same child ID,
+        # the edges are sorted by child_left
+        # See https://github.com/tskit-dev/tskit/discussions/2869
+        self.iedge_map_sorted_by_child = np.lexsort(
+            (
+                self.tables.iedges.parent,
+                self.tables.iedges.child_right,
+                self.tables.iedges.child_left,
+                self.tables.iedges.child,
+                self.tables.nodes.time[self.tables.iedges.child],  # Primary key
+            )
+        )
+        last_child = -1
+        for j, idx in enumerate(self.iedge_map_sorted_by_child):
+            ie = self.iedges[idx]
+            if ie.child != last_child:
+                self.parent_range[ie.child, 0] = j
+            if last_child != -1:
+                self.parent_range[last_child, 1] = j
+            last_child = ie.child
+        if last_child != -1:
+            self.parent_range[last_child, 1] = self.num_iedges
+
+        last_parent = -1
+        for ie in self.iedges:
+            if ie.parent != last_parent:
+                self.child_range[ie.child, 0] = j
+            if last_parent != -1:
+                self.child_range[last_parent, 1] = j
+            last_parent = ie.parent
+        if last_parent != -1:
+            self.child_range[last_parent, 1] = self.num_iedges
+
+    @property
+    def num_nodes(self):
+        return len(self.tables.nodes)
+
+    @property
+    def num_iedges(self):
+        return len(self.tables.iedges)
+
+    def samples(self):
+        return self.tables.samples()
+
+    @property
+    def nodes(self):
+        return Items(self.tables.nodes, Node)
+
+    @property
+    def iedges(self):
+        return Items(self.tables.iedges, IEdge)
+
+    def iedges_for_child(self, u):
+        """
+        Iterate over all iedges with child u
+        """
+        for i in range(*self.parent_range[u, :]):
+            yield self.iedges[self.iedge_map_sorted_by_child[i]]
+
+    def iedges_for_parent(self, u):
+        """
+        Iterate over all iedges with parent u
+        """
+        for i in range(*self.child_range[u, :]):
+            yield self.iedges[i]
+
+    def sequence_length(self, u):
+        """
+        Return the known sequence length of the node u (found from the
+        maximum position in the edges above or below this node)
+        """
+        maxpos = [ie.parent_max for ie in self.iedges_for_parent(u)]
+        maxpos += [ie.child_max for ie in self.iedges_for_child(u)]
+        if len(maxpos) > 0:
+            return max(maxpos)
+        return 0
+
+    def sample_resolve(self):
+        """
+        Run the equivalent of the Hudson algorithm on a fixed GIG.
+        The stack lists intervals for each node, and is ordered by
+        node time (oldest first), so that we can collect all the valid
+        intervals pointing to a node before passing inheritance
+        information upwards
+        """
+        stack = {u: P.empty() for u in np.argsort(-self.tables.nodes.time)}
+        new_tables = self.tables.copy()
+        new_tables.iedges.clear()
+        while len(stack) > 0:
+            u, intervals = stack.popitem()
+            if self.nodes[u].is_sample():
+                intervals = P.closedopen(-np.inf, np.inf)
+
+            # NOTE: if we had an index here sorted by left coord
+            # we could binary search to first match, and could
+            # break once e_right > left (I think?)
+            for j in range(*self.parent_range[u]):
+                ie = self.iedges[self.iedge_map_sorted_by_child[j]]
+                assert ie.child == u
+                for i in intervals:
+                    if ie.child_right > i.lower and i.upper > ie.child_left:
+                        inter_left = max(ie.child_left, i.lower)
+                        inter_right = min(ie.child_right, i.upper)
+                        parent_left = ie.transform_to_parent(
+                            inter_left, is_interval=True
+                        )
+                        parent_right = ie.transform_to_parent(
+                            inter_right, is_interval=True
+                        )
+                        if ie.is_inversion():
+                            stack[ie.parent] |= P.closedopen(parent_right, parent_left)
+                        else:
+                            stack[ie.parent] |= P.closedopen(parent_left, parent_right)
+                        new_tables.iedges.add_row(
+                            parent=ie.parent,
+                            child=ie.child,
+                            child_left=inter_left,
+                            child_right=inter_right,
+                            parent_left=parent_left,
+                            parent_right=parent_right,
+                        )
+        new_tables.sort()
+        return self.__class__(new_tables)
+
+
+class Items:
+    """
+    Class to wrap all the items in a table
+    """
+
+    def __init__(self, table, cls):
+        self.table = table
+        self.cls = cls
+
+    def __getitem__(self, index):
+        return self.cls(**self.table[index].asdict(), id=index)
+
+    def __len__(self):
+        return len(self.table)
+
+    def __iter__(self):
+        for i in range(len(self.table)):
+            yield self.cls(**self.table[i].asdict(), id=i)
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class IEdge(IEdgeTableRow):
+    """
+    A single interval edge in a Graph. Similar to an edge table row
+    but with an ID and various other useful methods that rely on
+    the graph being a consistent GIG (e.g. that abs(parent_span) == abs(child_span))
+    """
+
+    id: int  # NOQA: A003
+
+    @property
+    def span(self):
+        return self.child_span if self.child_span >= 0 else self.parent_span
+
+    @property
+    def parent_max(self):
+        """
+        The highest parent position on this edge (inversions can have left > right)
+        """
+        return max(self.parent_right, self.parent_left)
+
+    @property
+    def child_max(self):
+        """
+        The highest child position on this edge
+        """
+        return self.child_right
+
+    def is_inversion(self):
+        return self.child_span < 0 or self.parent_span < 0
+
+    def transform_to_parent(self, child_position, is_interval=False):
+        """
+        Transform a position from child coordinates to parent coordinates.
+        If this is an inversion and we are transforming a point position,
+        then an edge such as [0, 10) -> (10, 0] means that position 9 gets
+        transformed to 0, and position 10 is not transformed at all.
+
+        If, on the other hand, we are transforming an interval
+        """
+        if child_position < self.child_left or child_position > self.child_right:
+            raise ValueError(
+                f"Position {child_position} is not in the child interval for {self}"
+            )
+        if self.is_inversion():
+            if is_interval:
+                return (self.child_right - child_position + self.child_left) + (
+                    self.child_right - self.parent_left
+                )
+            else:
+                return (self.child_right - child_position + self.child_left - 1) + (
+                    self.child_right - self.parent_left
+                )
+        else:
+            return child_position - self.child_left + self.parent_left
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class Node(NodeTableRow):
+    """
+    A single node in a Graph. Similar to an node table row but with an ID.
+    """
+
+    id: int  # NOQA: A003

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+portion
 pytest
 pytest-cov
 pytest-xdist

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-import GeneticInheritanceGraph as gig
+import GeneticInheritanceGraph as gigl
 import msprime
 import pytest
 import tests.gigutil as gigutil
@@ -35,6 +35,9 @@ def ts_with_multiple_pops():
 
 @pytest.fixture(scope="session")
 def all_sv_types_gig():
+    """
+    Contains a single deletion, a single duplication, and a single inversion
+    """
     # p | c | c_left | c_right | p_left | p_right
     iedge_data = [
         (6, 0, 0, 300, 0, 300),
@@ -71,10 +74,11 @@ def all_sv_types_gig():
         (6, 0),
     ]
 
-    tables = gig.Tables()
+    tables = gigl.Tables()
     tables.iedges = gigutil.make_iedges_table(iedge_data, tables)
     tables.nodes = gigutil.make_nodes_table(node_data, tables)
-    return tables
+    tables.sort()
+    return gigl.Graph(tables)
 
 
 @pytest.fixture(scope="session")
@@ -82,23 +86,24 @@ def trivial_gig():
     # p | c | c_left | c_right | p_left | p_right
     iedge_data = [
         (4, 3, 0, 5, 0, 5),
-        (3, 0, 3, 0, 0, 3),
+        (3, 0, 0, 3, 3, 0),
         (3, 0, 3, 5, 3, 5),
         (4, 1, 0, 5, 0, 5),
         (4, 2, 0, 5, 0, 5),
     ]
     # time | flags
     node_data = [
-        (0, 1),
-        (0, 1),
-        (0, 1),
+        (0, gigl.NODE_IS_SAMPLE),
+        (0, gigl.NODE_IS_SAMPLE),
+        (0, gigl.NODE_IS_SAMPLE),
         (1, 0),
         (2, 0),
     ]
-    tables = gig.Tables()
-    tables.intervals = gigutil.make_iedges_table(iedge_data, tables)
+    tables = gigl.Tables()
+    tables.iedges = gigutil.make_iedges_table(iedge_data, tables)
     tables.nodes = gigutil.make_nodes_table(node_data, tables)
-    return tables
+    tables.sort()
+    return gigl.Graph(tables)
 
 
 @pytest.fixture(scope="session")
@@ -107,4 +112,4 @@ def gig_from_degree2_ts():
         5, sequence_length=10, recombination_rate=0.02, random_seed=1
     )
     assert ts.num_trees == 2
-    return gig.Tables.from_tree_sequence(ts)
+    return gigl.from_tree_sequence(ts)

--- a/tests/gigutil.py
+++ b/tests/gigutil.py
@@ -1,4 +1,4 @@
-import GeneticInheritanceGraph as gig
+import GeneticInheritanceGraph as gigl
 
 # Utilities for creating and editing gigs
 
@@ -24,5 +24,5 @@ def make_nodes_table(arr, tables):
     Make a nodes table from a list of tuples.
     """
     for row in arr:
-        tables.nodes.add_row(time=row[0], flags=row[1], individual=gig.NULL)
+        tables.nodes.add_row(time=row[0], flags=row[1], individual=gigl.NULL)
     return tables.nodes

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -35,6 +35,22 @@ class TestConstructor:
         assert gig.num_iedges == 1
         assert gig.num_samples == 1
 
+    def test_no_edges(self):
+        tables = gigl.Tables()
+        tables.nodes.add_row(0, flags=gigl.NODE_IS_SAMPLE)
+        tables.nodes.add_row(1, flags=0)
+        tables.nodes.add_row(1, flags=0)
+        gig = tables.graph()
+        assert gig.num_nodes == 3
+        assert gig.num_iedges == 0
+        assert gig.num_samples == 1
+        # Cached values should be defined but empty
+        assert gig.parent_range.shape == (gig.num_nodes, 2)
+        assert np.all(gig.parent_range == gigl.NULL)
+        assert gig.child_range.shape == (gig.num_nodes, 2)
+        assert np.all(gig.child_range == gigl.NULL)
+        assert gig.iedge_map_sorted_by_child.shape == (0,)
+
     def test_from_bad(self):
         with pytest.raises(
             ValueError, match="must be a GeneticInheritanceGraph.Tables"
@@ -233,6 +249,7 @@ class TestMethods:
     def test_edge_iterator(self, simple_ts):
         gig = gigl.from_tree_sequence(simple_ts)
         assert gig.num_iedges == simple_ts.num_edges
+        assert len(gig.iedges) == simple_ts.num_edges  # __len__ should work
         i = 0
         for iedge, edge in zip(gig.iedges, simple_ts.edges()):
             assert isinstance(iedge, gigl.graph.IEdge)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -255,6 +255,11 @@ class TestMethods:
         for u in gig.samples():
             assert gig.sequence_length(u) == simple_ts.sequence_length
 
+    def test_sequence_length_root(self, all_sv_types_gig):
+        # root will have no upward edges
+        root = all_sv_types_gig.num_nodes - 1
+        assert all_sv_types_gig.sequence_length(root) == 200
+
     def test_no_sequence_length(self):
         tables = gigl.Tables()
         tables.nodes.add_row(0, flags=gigl.NODE_IS_SAMPLE)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,132 @@
+import GeneticInheritanceGraph as gigl
+import numpy as np
+import pytest
+
+
+class TestFunctions:
+    # Test high level functions
+    def test_simple_from_tree_sequence(self, simple_ts):
+        assert simple_ts.num_trees > 1
+        gig = gigl.from_tree_sequence(simple_ts)
+        assert np.all(gig.samples() == gig.tables.samples())
+
+
+class TestMethods:
+    def test_edge_iterator(self, simple_ts):
+        gig = gigl.from_tree_sequence(simple_ts)
+        assert gig.num_iedges == simple_ts.num_edges
+        i = 0
+        for iedge, edge in zip(gig.iedges, simple_ts.edges()):
+            assert isinstance(iedge, gigl.graph.IEdge)
+            assert iedge.id == edge.id == i
+            i += 1
+        assert i == simple_ts.num_edges
+
+    def test_iedges_for_child(self, simple_ts):
+        gig = gigl.from_tree_sequence(simple_ts)
+        edges = set()
+        for u in range(gig.num_nodes):
+            for iedge in gig.iedges_for_child(u):
+                assert isinstance(iedge, gigl.graph.IEdge)
+                assert iedge.child == u
+                edges.add(iedge.id)
+        assert len(edges) == simple_ts.num_edges
+
+    def test_sequence_length(self, simple_ts):
+        gig = gigl.from_tree_sequence(simple_ts)
+        for u in gig.samples():
+            assert gig.sequence_length(u) == simple_ts.sequence_length
+
+    def test_no_sequence_length(self):
+        tables = gigl.Tables()
+        tables.nodes.add_row(0, flags=gigl.NODE_IS_SAMPLE)
+        gig = tables.graph()
+        for u in gig.samples():
+            assert gig.sequence_length(u) == 0
+
+
+class TestSampleResolving:
+    """
+    Sample resolving is complicated enough that we want a whole class to test
+    """
+
+    def test_simple_sample_resolve(self, simple_ts):
+        gig = gigl.from_tree_sequence(simple_ts.simplify())
+        new_gig = gig.sample_resolve()  # Shouldn't make any changes
+        assert gig.tables == new_gig.tables
+
+    def test_all_svs_sample_resolve(self, all_sv_types_gig):
+        """
+        The all_sv_types_gig is not sample resolved, so we should see changes
+        (in particular, 10->11 should be split into two edges)
+        """
+        new_gig = all_sv_types_gig.sample_resolve()  # Shouldn't make any changes
+        assert new_gig.num_iedges - all_sv_types_gig.num_iedges == 1
+        new_edges = iter(new_gig.tables.iedges)
+        for iedge_row in all_sv_types_gig.tables.iedges:
+            if iedge_row.parent == 11 and iedge_row.child == 10:
+                assert iedge_row.parent_left == iedge_row.child_left == 0
+                assert iedge_row.parent_right == iedge_row.child_right == 200
+                new_iedge = next(new_edges)
+                assert new_iedge.parent_left == new_iedge.child_left == 0
+                assert new_iedge.parent_right == new_iedge.child_right == 50
+                new_iedge = next(new_edges)
+                assert new_iedge.parent_left == new_iedge.child_left == 150
+                assert new_iedge.parent_right == new_iedge.child_right == 200
+            else:
+                assert iedge_row == next(new_edges)
+
+
+class TestIEdge:
+    """
+    Test the wrapper around a single iedge
+    """
+
+    @pytest.mark.parametrize(
+        "name",
+        ["parent", "child", "parent_left", "parent_right", "child_left", "child_right"],
+    )
+    def test_edge_accessors(self, simple_ts, name):
+        gig = gigl.from_tree_sequence(simple_ts)
+        suffix = name.split("_")[-1]
+
+        ie = gig.iedges[0]
+        assert getattr(ie, name) == getattr(simple_ts.edge(0), suffix)
+
+    def test_span(self, all_sv_types_gig):
+        for ie in all_sv_types_gig.iedges:
+            assert ie.span == np.abs(ie.child_right - ie.child_left)
+            assert ie.span == np.abs(ie.parent_right - ie.parent_left)
+
+    def test_is_inversion(self, all_sv_types_gig):
+        num_inversions = 0
+        for ie in all_sv_types_gig.iedges:
+            if ie.is_inversion():
+                num_inversions += 1
+                assert ie.parent_right - ie.parent_left < 0
+        assert num_inversions == 1
+
+    def test_notransform(self):
+        ie = gigl.graph.IEdge(
+            0, 1, parent_left=10, parent_right=20, child_left=10, child_right=20, id=0
+        )
+        assert ie.transform_to_parent(child_position=12) == 12
+        assert ie.transform_to_parent(child_position=17) == 17
+
+    def test_transform_linear(self):
+        ie = gigl.graph.IEdge(
+            0, 1, parent_left=10, parent_right=20, child_left=0, child_right=10, id=0
+        )
+        assert ie.transform_to_parent(child_position=2) == 12
+        assert ie.transform_to_parent(child_position=7) == 17
+
+    def test_transform_inversion(self):
+        ie = gigl.graph.IEdge(
+            0, 1, parent_left=20, parent_right=10, child_left=10, child_right=20, id=0
+        )
+        assert ie.transform_to_parent(child_position=10) == 19
+        assert ie.transform_to_parent(child_position=11) == 18
+        assert ie.transform_to_parent(child_position=12) == 17
+        assert ie.transform_to_parent(child_position=17) == 12
+        assert ie.transform_to_parent(child_position=18) == 11
+        assert ie.transform_to_parent(child_position=19) == 10

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -52,7 +52,15 @@ class TestCopy:
         tables_copy = tables.copy()
         assert tables_copy == tables
         assert tables_copy is not tables
+
+    def test_equals(self, trivial_gig):
+        tables = trivial_gig.tables
+        tables_copy = tables.copy()
+        assert tables_copy == tables
         tables_copy.iedges.clear()
+        assert tables_copy != tables
+        tables_copy = tables.copy()
+        tables_copy.time_units = "abcde"
         assert tables_copy != tables
 
 
@@ -189,6 +197,13 @@ class TestIEdgeAttributes:
         assert np.all(
             getattr(tables.iedges, name) == getattr(simple_ts, "edges_" + suffix)
         )
+
+
+class TestIndividualAttributes:
+    def test_asdict(self, simple_ts):
+        tables = gigl.Tables.from_tree_sequence(simple_ts)
+        for i, ind in enumerate(tables.individuals):
+            assert ind.asdict()["parents"] == simple_ts.individual(i).parents
 
 
 class TestNodeAttributes:

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -1,4 +1,4 @@
-import GeneticInheritanceGraph as gig
+import GeneticInheritanceGraph as gigl
 import msprime
 import numpy as np
 import pytest
@@ -8,7 +8,7 @@ class TestCreation:
     # Test creation of a set of GiGtables
     def test_simple_from_tree_sequence(self, simple_ts):
         assert simple_ts.num_trees > 1
-        tables = gig.Tables.from_tree_sequence(simple_ts)
+        tables = gigl.Tables.from_tree_sequence(simple_ts)
         assert len(tables.nodes) == simple_ts.num_nodes
         assert len(tables.iedges) == simple_ts.num_edges
         # test conversion from float to int for genomic coordinates
@@ -22,7 +22,7 @@ class TestCreation:
     @pytest.mark.parametrize("time", [0, 1])
     def test_simple_from_tree_sequence_with_timedelta(self, simple_ts, time):
         assert simple_ts.num_trees > 1
-        tables = gig.Tables.from_tree_sequence(simple_ts, timedelta=time)
+        tables = gigl.Tables.from_tree_sequence(simple_ts, timedelta=time)
         assert tables.nodes[0].time == simple_ts.node(0).time + time
 
     def test_mutations_not_implemented_error(self, simple_ts_with_mutations):
@@ -30,7 +30,7 @@ class TestCreation:
         assert ts_tables.mutations.num_rows > 0
         assert ts_tables.sites.num_rows > 0
         with pytest.raises(NotImplementedError):
-            gig.Tables.from_tree_sequence(simple_ts_with_mutations)
+            gigl.Tables.from_tree_sequence(simple_ts_with_mutations)
 
     def test_populations_not_implemented_error(self, ts_with_multiple_pops):
         # No need to test for migrations, since they necessarily
@@ -38,58 +38,90 @@ class TestCreation:
         ts_tables = ts_with_multiple_pops.tables
         assert ts_tables.populations.num_rows > 1
         with pytest.raises(NotImplementedError):
-            gig.Tables.from_tree_sequence(ts_with_multiple_pops)
+            gigl.Tables.from_tree_sequence(ts_with_multiple_pops)
 
     def test_noninteger_positions(self):
         bad_ts = msprime.simulate(10, recombination_rate=10, random_seed=1)
         with pytest.raises(ValueError, match="not an integer"):
-            gig.Tables.from_tree_sequence(bad_ts)
+            gigl.Tables.from_tree_sequence(bad_ts)
+
+
+class TestCopy:
+    def test_copy(self, trivial_gig):
+        tables = trivial_gig.tables
+        tables_copy = tables.copy()
+        assert tables_copy == tables
+        assert tables_copy is not tables
+        tables_copy.iedges.clear()
+        assert tables_copy != tables
 
 
 class TestExtractColumn:
     # Test extraction of columns from a gig
     def test_invalid_column_name(self, trivial_gig):
+        tables = trivial_gig.tables
         with pytest.raises(AttributeError):
-            trivial_gig.iedges.foobar
+            tables.iedges.foobar
 
     def test_column_from_empty_table(self, trivial_gig):
-        assert len(trivial_gig.individuals.parents) == 0
+        tables = trivial_gig.tables
+        assert len(tables.individuals.parents) == 0
 
     def test_extracted_columns(self, trivial_gig):
-        assert np.array_equal(trivial_gig.nodes.time, [0, 0, 0, 1, 2])
-        assert np.array_equal(trivial_gig.nodes.flags, [1, 1, 1, 0, 0])
-        assert np.array_equal(trivial_gig.iedges.parent, [4, 3, 3, 4, 4])
-        assert np.array_equal(trivial_gig.iedges.child_left, [0, 3, 3, 0, 0])
+        tables = trivial_gig.tables
+        assert np.array_equal(tables.nodes.time, [0, 0, 0, 1, 2])
+        assert np.array_equal(tables.nodes.flags, [1, 1, 1, 0, 0])
+        assert np.array_equal(tables.iedges.parent, [3, 3, 4, 4, 4])
+        assert np.array_equal(tables.iedges.child_left, [0, 3, 0, 0, 0])
 
 
 class TestMethods:
     def test_samples(self, simple_ts):
-        tables = gig.Tables.from_tree_sequence(simple_ts)
+        tables = gigl.Tables.from_tree_sequence(simple_ts)
         assert np.array_equal(tables.samples(), simple_ts.samples())
+
+    def test_sort(self):
+        tables = gigl.Tables()
+        tables.nodes.add_row(0, flags=gigl.NODE_IS_SAMPLE)
+        tables.nodes.add_row(0, flags=gigl.NODE_IS_SAMPLE)
+        tables.nodes.add_row(1)
+        tables.nodes.add_row(2)
+        tables.iedges.add_row(3, 2, 5, 0, 0, 5)
+        tables.iedges.add_row(2, 0, 0, 5, 0, 5)
+        tables.iedges.add_row(3, 0, 0, 5, 0, 5)  # Out of order
+        tables.sort()
+        assert tables.iedges[0].parent == 2
+        assert tables.iedges[1].parent == 3
+        assert tables.iedges[2].parent == 3
+        assert tables.iedges[0].child == 0
+        assert tables.iedges[1].child == 0
+        assert tables.iedges[2].child == 2
 
 
 class TestBaseTable:
     # Test various basic table methods
     def test_append_row_values(self, trivial_gig):
-        assert len(trivial_gig.nodes) == 5
-        trivial_gig.nodes.append({"time": 3, "flags": 0})
-        assert len(trivial_gig.nodes) == 6
-        assert trivial_gig.nodes.time[-1] == 3
-        assert trivial_gig.nodes.flags[-1] == 0
+        tables = trivial_gig.tables
+        assert len(tables.nodes) == 5
+        tables.nodes.append({"time": 3, "flags": 0})
+        assert len(tables.nodes) == 6
+        assert tables.nodes.time[-1] == 3
+        assert tables.nodes.flags[-1] == 0
 
     def test_iteration(self, trivial_gig):
-        assert len(trivial_gig.nodes) > 0
-        for row in trivial_gig.nodes:
-            assert isinstance(row, gig.tables.NodeTableRow)
-        assert len(trivial_gig.iedges) > 0
-        for row in trivial_gig.iedges:
-            assert isinstance(row, gig.tables.IEdgeTableRow)
+        tables = trivial_gig.tables
+        assert len(tables.nodes) > 0
+        for row in tables.nodes:
+            assert isinstance(row, gigl.tables.NodeTableRow)
+        assert len(tables.iedges) > 0
+        for row in tables.iedges:
+            assert isinstance(row, gigl.tables.IEdgeTableRow)
 
 
 class TestIEdgeTable:
     def test_append_integer_coords(self):
-        tables = gig.Tables()
-        u = tables.nodes.add_row(flags=gig.NODE_IS_SAMPLE, time=0)
+        tables = gigl.Tables()
+        u = tables.nodes.add_row(flags=gigl.NODE_IS_SAMPLE, time=0)
         tables.iedges.add_row(0, u, 0, 1, 1, 0)
         assert tables.iedges.parent_left[0] == 0
         assert tables.iedges.child_left[0] == 1
@@ -104,7 +136,7 @@ class TestStringRepresentations:
         assert "tskit" not in output
 
     def test_identifiable_values_from_str(self):
-        tables = gig.Tables()
+        tables = gigl.Tables()
         nodes = [(0, 3.1451), (1, 7.4234)]
         iedge = [1, 0, 222, 777, 322, 877]
         for node in nodes:
@@ -126,7 +158,7 @@ class TestStringRepresentations:
     @pytest.mark.parametrize("num_rows", [0, 10, 40, 50])
     def test_repr_html(self, num_rows):
         # Based on the corresponding test code in tskit
-        nodes = gig.Tables().nodes
+        nodes = gigl.Tables().nodes
         for _ in range(num_rows):
             nodes.append({"time": 0, "flags": 0})
         html = nodes._repr_html_()
@@ -142,16 +174,16 @@ class TestStringRepresentations:
 
 class TestIEdgeAttributes:
     def test_non_ts_attributes(self, simple_ts):
-        tables = gig.Tables.from_tree_sequence(simple_ts)
+        tables = gigl.Tables.from_tree_sequence(simple_ts)
         assert tables.iedges.edge.dtype == np.int64
-        assert np.all(tables.iedges.edge == gig.NULL)
+        assert np.all(tables.iedges.edge == gigl.NULL)
 
     @pytest.mark.parametrize(
         "name",
         ["parent", "child", "parent_left", "parent_right", "child_left", "child_right"],
     )
     def test_ts_attributes(self, simple_ts, name):
-        tables = gig.Tables.from_tree_sequence(simple_ts)
+        tables = gigl.Tables.from_tree_sequence(simple_ts)
         assert getattr(tables.iedges, name).dtype == np.int64
         suffix = name.split("_")[-1]
         assert np.all(
@@ -161,9 +193,9 @@ class TestIEdgeAttributes:
 
 class TestNodeAttributes:
     def test_flags(self, simple_ts):
-        tables = gig.Tables.from_tree_sequence(simple_ts)
+        tables = gigl.Tables.from_tree_sequence(simple_ts)
         assert np.all(tables.nodes.flags == simple_ts.nodes_flags)
 
     def test_child(self, simple_ts):
-        tables = gig.Tables.from_tree_sequence(simple_ts)
+        tables = gigl.Tables.from_tree_sequence(simple_ts)
         assert np.all(tables.iedges.child == simple_ts.edges_child)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,4 @@
-import GeneticInheritanceGraph as gig
+import GeneticInheritanceGraph as gigl
 import GeneticInheritanceGraph.util as util
 import pytest
 
@@ -12,10 +12,10 @@ def test_truncate_rows():
 
 
 def test_set_print_options():
-    assert gig._print_options == {"max_lines": 40}
+    assert gigl._print_options == {"max_lines": 40}
     util.set_print_options(max_lines=None)
-    assert gig._print_options == {"max_lines": None}
+    assert gigl._print_options == {"max_lines": None}
     util.set_print_options(max_lines=50)
-    assert gig._print_options == {"max_lines": 50}
+    assert gigl._print_options == {"max_lines": 50}
     with pytest.raises(TypeError):
         util.set_print_options(40)


### PR DESCRIPTION
To represent a immutable, valid GIG. This also includes a method to "sample resolve" a GIG, although it's not extensively tested yet.

@duncanMR - after writing the code, I think that it's easier to have child_left < child_right for inversions (rather than the same for parents), because in my `sample_resolve` code, I check the left and right in the child against the existing intervals as we go up the graph. See what you think?

There's a lot of extra functionality in this PR, sorry, but I think it's useful. I've tried to stick to the tskit style as much as possible, apart from the following:

```
gig.edges  # can iterate over, like ts.edges() but without the braces
gig.edges[0]  # same as ts.edge(0)
gig.nodes  # like ts.nodes()
gig.node[0]  # like ts.node(0)
gig.sequence_length(u)  # has to be per node: find a max sequence length for node u, using the edges
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an enhanced genetic inheritance graph representation, including a new `Graph` class for efficient data manipulation.
  - Added functionality to construct genetic inheritance graphs from tree sequences.

- **Improvements**
  - Improved validation logic within the genetic inheritance graph framework for better data integrity.
  - Enhanced graph manipulation methods for more robust and versatile usage.

- **Documentation**
  - Updated test documentation to better reflect the purpose and usage of each test fixture.

- **Refactor**
  - Renamed module import alias for clarity and consistency across test files.
  - Streamlined node and edge table creation with updated references.

- **Bug Fixes**
  - Fixed issues in the genetic inheritance graph data classes to ensure immutability and correct data representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->